### PR TITLE
Fix 1.13+ servers crash method

### DIFF
--- a/api/src/main/java/com/ruinscraft/panilla/api/nbt/checks/NbtCheck_display.java
+++ b/api/src/main/java/com/ruinscraft/panilla/api/nbt/checks/NbtCheck_display.java
@@ -57,6 +57,7 @@ public class NbtCheck_display extends NbtCheck {
                     name = createTextFromJsonArray(jsonArray);
                 } catch (Exception e) {
                     // could not parse Json
+                    return NbtCheckResult.CRITICAL;  // can cause crashes
                 }
             }
 


### PR DESCRIPTION
This commit fixes an exploit that would instantly crash the server, or crash a player who gets this item in their inventory.

Panilla can fix this at STRICT (for OPs) level, but I think it should be fixed at any level of strictness.