### PR TITLE
Fix ArrayIndexOutOfBounds when check book pages

### DIFF
--- a/api/src/main/java/com/ruinscraft/panilla/api/nbt/checks/NbtCheck_pages.java
+++ b/api/src/main/java/com/ruinscraft/panilla/api/nbt/checks/NbtCheck_pages.java
@@ -26,8 +26,14 @@ public class NbtCheck_pages extends NbtCheck {
     private static short[] createCharMap(String string) {
         short[] charMap = Arrays.copyOf(EMPTY_CHAR_MAP, EMPTY_CHAR_MAP.length);
 
+        if (string == null || string.isEmpty()) {
+            return charMap;
+        }
+
         for (char c : string.toCharArray()) {
-            charMap[c]++;
+            if (c < MINECRAFT_UNICODE_MAX) {
+                charMap[c]++;
+            }
         }
 
         return charMap;


### PR DESCRIPTION
Fix error  `ArrayIndexOutOfBoundsException: Index 65535 out of bounds for length 65535` when plugin checked book like this.

![2024-02-06_19 16 01](https://github.com/ds58/Panilla/assets/61569423/6cd180e5-3568-4808-aef7-da5c8d661d04)
